### PR TITLE
stop using yield to call recursive func

### DIFF
--- a/lib/rack/camel_snake/formatter.rb
+++ b/lib/rack/camel_snake/formatter.rb
@@ -2,16 +2,12 @@ module Rack
   class CamelSnake
     module Formatter
       # hashのkeyを再帰的に変換: blockで変換処理を渡します
-      def self.formatter(args)
-        key_converter = lambda do |key|
-          key.is_a?(String) ? yield(key) : key
-        end
-
+      def self.formatter(args, converter)
         case args
           when Hash
-            args.reduce({}){ |hash, (key, value)| hash.merge(key_converter.call(key) => formatter(value){ yield }) }
+            args.reduce({}){ |hash, (key, value)| hash.merge(converter.call(key) => formatter(value, converter){ yield }) }
           when Array
-            args.reduce([]){ |array, value| array << formatter(value){ yield } }
+            args.reduce([]){ |array, value| array << formatter(value, converter){ yield } }
           else
             args
         end

--- a/lib/rack/camel_snake/refinements.rb
+++ b/lib/rack/camel_snake/refinements.rb
@@ -5,11 +5,19 @@ module Rack
     module Refinements
       refine Oj.singleton_class do
         def camelize(input)
-          dump(Rack::CamelSnake::Formatter.formatter(load(input)){ |key| key.to_camel })
+          to_camel = lambda do |key|
+            key.is_a?(String) ? key.to_camel : key
+          end
+
+          dump(Rack::CamelSnake::Formatter.formatter(load(input), to_camel))
         end
 
         def snakify(input)
-          dump(Rack::CamelSnake::Formatter.formatter(load(input)){ |key| key.to_snake })
+          to_snake = lambda do |key|
+            key.is_a?(String) ? key.to_snake : key
+          end
+
+          dump(Rack::CamelSnake::Formatter.formatter(load(input), to_snake))
         end
       end
 

--- a/spec/rack/camel_snake_spec.rb
+++ b/spec/rack/camel_snake_spec.rb
@@ -24,8 +24,8 @@ describe Rack::CamelSnake do
   end
 
   describe 'rewrite_request/response' do
-    let(:camel){ { 'isDone'  => 'hoge', 'order' => 1, 'taskTitle'  => 'title' } }
-    let(:snake){ { 'is_done' => 'hoge', 'order' => 1, 'task_title' => 'title' } }
+    let(:camel){ [{ 'isDone'  => 'hoge', 'order' => 1, 'taskTitle'  => 'title' }, { 'isDone'  => 'hoge', 'order' => 1, 'taskTitle'  => 'title' }] }
+    let(:snake){ [{ 'is_done' => 'hoge', 'order' => 1, 'task_title' => 'title' }, { 'is_done' => 'hoge', 'order' => 1, 'task_title' => 'title' }] }
 
     it 'rewrite request with content_type == json' do
       mock_env_json = {


### PR DESCRIPTION
#5 の件の修正です。`yield`だとスコープが変わってしまうので、仕方なく、lambdaを渡すようにしました。
