### PR TITLE
Adjust the request's content-length.

### DIFF
--- a/lib/rack/camel_snake.rb
+++ b/lib/rack/camel_snake.rb
@@ -24,7 +24,7 @@ module Rack
         input = env['rack.input'].read
         snakified = Oj.snakify(input)
         env['rack.input'] = StringIO.new(snakified)
-        env['CONTENT_LENGTH'] = snakified.length
+        env['CONTENT_LENGTH'] = snakified.bytesize
       end
     end
 

--- a/lib/rack/camel_snake.rb
+++ b/lib/rack/camel_snake.rb
@@ -22,7 +22,9 @@ module Rack
     def rewrite_request_body_to_snake(env)
       if env['CONTENT_TYPE'] == 'application/json'
         input = env['rack.input'].read
-        env['rack.input'] = StringIO.new(Oj.snakify(input))
+        snakified = Oj.snakify(input)
+        env['rack.input'] = StringIO.new(snakified)
+        env['CONTENT_LENGTH'] = snakified.length
       end
     end
 

--- a/spec/rack/camel_snake_spec.rb
+++ b/spec/rack/camel_snake_spec.rb
@@ -30,12 +30,12 @@ describe Rack::CamelSnake do
     it 'rewrite request with content_type == json' do
       mock_env_json = {
         'CONTENT_TYPE' => 'application/json',
-        'CONTENT_LENGTH' => JSON.dump(camel).length,
+        'CONTENT_LENGTH' => JSON.dump(camel).bytesize,
         'rack.input' => StringIO.new(JSON.dump(camel))
       }
       app.send(:rewrite_request_body_to_snake, mock_env_json)
       expect(JSON.parse(mock_env_json['rack.input'].read)).to eq snake
-      expect(mock_env_json['CONTENT_LENGTH']).to eq JSON.dump(snake).length
+      expect(mock_env_json['CONTENT_LENGTH']).to eq JSON.dump(snake).bytesize
     end
 
     it 'not rewrite request with another content_type' do

--- a/spec/rack/camel_snake_spec.rb
+++ b/spec/rack/camel_snake_spec.rb
@@ -30,10 +30,12 @@ describe Rack::CamelSnake do
     it 'rewrite request with content_type == json' do
       mock_env_json = {
         'CONTENT_TYPE' => 'application/json',
+        'CONTENT_LENGTH' => JSON.dump(camel).length,
         'rack.input' => StringIO.new(JSON.dump(camel))
       }
       app.send(:rewrite_request_body_to_snake, mock_env_json)
       expect(JSON.parse(mock_env_json['rack.input'].read)).to eq snake
+      expect(mock_env_json['CONTENT_LENGTH']).to eq JSON.dump(snake).length
     end
 
     it 'not rewrite request with another content_type' do


### PR DESCRIPTION
When changing the body of the request, set the CONTENT_LENGTH header to the new length.

(Rails expects the content length to be correct.)
